### PR TITLE
Update for rust nightly

### DIFF
--- a/lib.rs
+++ b/lib.rs
@@ -3,7 +3,7 @@ extern crate libc;
 use libc::c_int;
 
 #[repr(C)]
-#[derive(Copy)]
+#[derive(Clone, Copy)]
 pub struct RawEvent {
     pub etype: u8,
     pub emod: u8,


### PR DESCRIPTION
It seems that `#[derive(Copy)]` now requires `Clone` to also be implemented for the type. The `RawEvent` struct derived `Copy` without `Clone`.