### PR TITLE
README.md: point out that termbox is downloaded at compile time

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
 # termbox-sys
 
-Low level bindings for the termbox library
+Low level bindings for the [termbox] library, which is downloaded at compile
+time
+
+[termbox]: https://github.com/nsf/termbox


### PR DESCRIPTION
(This commit also adds a link to the termbox repository to the readme file.)

I'm not sure if this commit might come across a little snarky; if so, I apologize.