### PR TITLE
Fix ARM

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -48,7 +48,7 @@ fn configure() {
     } else if target.contains("x86_64") {
         cflags = "-m64 -fPIC"
     } else {
-        cflags = ""
+        cflags = "-fPIC"
     }
     println!("waf configure: setting CFLAGS to: `{}`", cflags);
     env::set_var("CFLAGS", cflags);


### PR DESCRIPTION
Necessary on ARM Linux to avoid link errors like this one:

```shell
error: linking with `cc` failed: exit code: 1
/usr/bin/ld.gold.real: error: /tmp/iota-master/target/release/deps/libtermbox_sys-fcbe85de9ba3cc69.rlib(r-termbox-utf8.c.2.o): requires unsupported dynamic reloc R_ARM_THM_MOVW_ABS_NC; recompile with -fPIC
collect2: error: ld returned 1 exit status
````