### PR TITLE
Allow crate to be built in path with spaces

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -11,7 +11,8 @@ fn main() {
     build();
     install(&dst);
     clean();
-    println!("cargo:rustc-flags=-L {} -l static=termbox", dst.join("lib").display());
+    println!("cargo:rustc-link-search={}", dst.join("lib").display());
+    println!("cargo:rustc-link-lib=static=termbox");
 }
 
 fn setup() {


### PR DESCRIPTION
See rust-lang/cargo#1015

As it is currently, this crate will output the following error upon attempt to build it in a path containing spaces: 

```
error: Only `-l` and `-L` flags are allowed in build script of `termbox-sys v0.2.9`: `-L /mnt/c/Users/Username With Spaces/Desktop/rust_projects/chat-rs/client/target/debug/build/termbox-sys-c95d742f97f59a86/out/lib -l static=termbox`
```

The changes made in this PR allowed me to build the crate without issue. 