### PR TITLE
prevent waf from putting the static lib into lib64

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -42,6 +42,7 @@ fn configure() {
     let mut cmd = waf();
     cmd.arg("configure");
     cmd.arg("--prefix=/");
+    cmd.arg("--libdir=/lib");
 
     let target = env::var("TARGET").unwrap();
     let mut cflags;


### PR DESCRIPTION
Waf has a hardcoded section that forces usage of lib64 when the /usr/lib64 or /usr/local/lib64 paths exist. Meanwhile, `build.rs` expects the library to be in `lib` always. This fixes compilation of various projects that depend on `termbox-sys` directly or indirectly, by forcing the library path.