### PR TITLE
Force Waf to Use Python2

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -81,7 +81,8 @@ fn waf() -> Command {
     let cargo_dir = Path::new(&manifest_dir);
     let termbox_dir = cargo_dir.join(".termbox");
     let waf_file = fs::canonicalize(&termbox_dir.join("waf")).expect("Invalid location of waf file");
-    let mut cmd = Command::new(waf_file);
+    let mut cmd = Command::new("/bin/python2");
+    cmd.arg(waf_file);
     cmd.current_dir(&termbox_dir);
     cmd
 }

--- a/build.rs
+++ b/build.rs
@@ -81,7 +81,7 @@ fn waf() -> Command {
     let cargo_dir = Path::new(&manifest_dir);
     let termbox_dir = cargo_dir.join(".termbox");
     let waf_file = fs::canonicalize(&termbox_dir.join("waf")).expect("Invalid location of waf file");
-    let mut cmd = Command::new("/bin/python2");
+    let mut cmd = Command::new("/usr/bin/python2");
     cmd.arg(waf_file);
     cmd.current_dir(&termbox_dir);
     cmd


### PR DESCRIPTION
While building termbox, waf uses `python` to build, but on many systems, python refers to python3 rather than python2. This causes the build to fail.